### PR TITLE
Fix footer not sticking to bottom

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -123,7 +123,7 @@ body {
     text-rendering: optimizeLegibility;
     /* background: linear-gradient(to bottom, #EEFFEE 0%, var(--color-bg) 25vh); */
     background: var(--color-bg);
-    min-height: 50vh;
+    min-height: 100vh;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     -moz-font-feature-settings: "liga" on;
@@ -280,10 +280,17 @@ blockquote p {
 
 /* Layout
 /* ---------------------------------------------------------- */
+.viewport {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
 .container {
     max-width: 1920px;
     margin: 0 auto;
     padding: 0 4vw;
+    width: 100%;
 }
 
 .inner {
@@ -1152,6 +1159,7 @@ h2.read-more-title {
     padding: 2rem 0 2rem;
     background: black;
     border-radius: 16px;
+    margin-top: auto;
 }
 
 .post-template .site-footer {


### PR DESCRIPTION
The footer is not sticking to the bottom when there is not enough content to push it down. This update uses `display: flex` on the parent element and `margin-top: auto` on the footer to fix this.